### PR TITLE
fix: login ui

### DIFF
--- a/app/sign-in/SignInForm.tsx
+++ b/app/sign-in/SignInForm.tsx
@@ -59,7 +59,7 @@ export const SignInForm = () => {
                   }}
                   data-cy="email-input"
                 />
-                <div style={{ width: '300px' }}>
+                <div style={{ width: '300px', minHeight: '50px' }}>
                   <ErrorMessage
                     name="email"
                     component="div"


### PR DESCRIPTION
# Summary

- Add a fixed `width` for the `ErrorMessage` component.
- Add `min-height` for the `ErrorMessage` component.

# Details 

- The login modal will maintain its dimension when error messages are displayed.

# Evidences

## Login modal width and height increased by error messages.
![unfixed](https://github.com/MatHenriquez/chessterix_front/assets/104148269/d8fdf85b-9edc-465f-a5a4-cb2ecd805999)

## Corrected login modal.
![fixed](https://github.com/MatHenriquez/chessterix_front/assets/104148269/b6232afc-ab42-45c7-934e-8e6ecd2217f2)