### PR TITLE
fix: landing page title

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -6,6 +6,14 @@ const config: Config = {
     './components/**/*.{js,ts,jsx,tsx,mdx}',
     './app/**/*.{js,ts,jsx,tsx,mdx}'
   ],
+
+  safelist: [
+    {
+      pattern: /row-span-(2|4)/
+    },
+    'place-content-center'
+  ],
+
   theme: {
     extend: {
       colors: {
@@ -32,4 +40,5 @@ const config: Config = {
   },
   plugins: []
 };
+
 export default config;


### PR DESCRIPTION
# Summary

* Add a `safelist` to the configuration to include the `row-span-(2|4)` pattern and the `place-content-center` class, ensuring these classes are always included in the final CSS output.
* Add a newline before the `export default config;` statement for improved readability.

# Details

- Fix height distribution of the landing page title and buttons.

# Evidences

## Before fix
<img width="1279" alt="prod" src="https://github.com/user-attachments/assets/892d48d3-9728-4bc8-a928-111ac86d63b4" />

# After fix
<img width="1280" alt="local" src="https://github.com/user-attachments/assets/4c35b213-48b0-4488-a79f-5bce01e952dc" />