### PR TITLE
feat: knights

### DIFF
--- a/app/board/page.css
+++ b/app/board/page.css
@@ -42,8 +42,8 @@
   background: rgba(255, 255, 255, 0.3);
   backdrop-filter: blur(8px);
   -webkit-backdrop-filter: blur(8px);
-  border: 1px solid rgba(255, 255, 255, 0.18);
-  box-shadow: 0 8px 32px 0 rgba(31, 38, 135, 0.37);
+  border: 1px solid rgba(135, 31, 31, 0.18);
+  box-shadow: 0 8px 64px 0 rgba(135, 31, 31, 0.75);
 }
 
 @media (max-width: 768px) {

--- a/app/utils/arbiter/arbiter.ts
+++ b/app/utils/arbiter/arbiter.ts
@@ -1,4 +1,4 @@
-import { getRookMoves } from './getMoves';
+import { getKnightMoves, getRookMoves } from './getMoves';
 
 const arbiter = {
   getRegularMoves: function (
@@ -10,6 +10,11 @@ const arbiter = {
     if (piece.endsWith('r')) {
       return getRookMoves(rank, fileIndex, position, piece);
     }
+
+    if (piece.endsWith('n')) {
+      return getKnightMoves(rank, fileIndex, position);
+    }
+
     return [];
   }
 };

--- a/app/utils/arbiter/getMoves.ts
+++ b/app/utils/arbiter/getMoves.ts
@@ -42,3 +42,41 @@ export const getRookMoves = (
 
   return moves;
 };
+
+export const getKnightMoves = (
+  rank: number,
+  fileIndex: number,
+  currentPosition: string[][]
+) => {
+  const moves: [number, number][] = [];
+  const currentPlayer = currentPosition[rank][fileIndex][0];
+  const opponent = currentPlayer === 'w' ? 'b' : 'w';
+
+  const candidates = [
+    [-2, -1],
+    [-2, 1],
+    [-1, -2],
+    [-1, 2],
+    [1, -2],
+    [1, 2],
+    [2, -1],
+    [2, 1]
+  ];
+
+  candidates.forEach((candidate) => {
+    const newRank = rank + candidate[0];
+    const newFile = fileIndex + candidate[1];
+
+    if (newRank < 0 || newRank > 7 || newFile < 0 || newFile > 7) {
+      return;
+    }
+
+    const cell = currentPosition[newRank][newFile];
+
+    if (cell === '' || cell.startsWith(opponent)) {
+      moves.push([newRank, newFile]);
+    }
+  });
+
+  return moves;
+};


### PR DESCRIPTION
# Summary

- Implement the `getKnightMoves` function to calculate valid moves for knights based on their unique movement pattern and board constraints.
- Add support for knight moves by importing `getKnightMoves` and extending the `getRegularMoves` function to handle knight pieces. Implemented the `getKnightMoves` function to calculate valid moves for knights based on their unique movement pattern and board constraints.
- Update the board's border and shadow styles to use a darker red tone (`rgba(135, 31, 31)`) for a more dramatic visual effect.

# Details

- Add knights movement funcionality.
- Enhance board shadow effect.

# Details

## Kinght Candidate Moves

![image](https://github.com/user-attachments/assets/84722c5b-e70c-48d2-9ee1-77b194b483ad)