### PR TITLE
feat: bishops

### DIFF
--- a/app/utils/arbiter/arbiter.ts
+++ b/app/utils/arbiter/arbiter.ts
@@ -1,4 +1,4 @@
-import { getKnightMoves, getRookMoves } from './getMoves';
+import { getBishopMoves, getKnightMoves, getRookMoves } from './getMoves';
 
 const arbiter = {
   getRegularMoves: function (
@@ -13,6 +13,10 @@ const arbiter = {
 
     if (piece.endsWith('n')) {
       return getKnightMoves(rank, fileIndex, position);
+    }
+
+    if (piece.endsWith('b')) {
+      return getBishopMoves(rank, fileIndex, position, piece);
     }
 
     return [];

--- a/app/utils/arbiter/getMoves.ts
+++ b/app/utils/arbiter/getMoves.ts
@@ -80,3 +80,48 @@ export const getKnightMoves = (
 
   return moves;
 };
+
+export const getBishopMoves = (
+  rank: number,
+  fileIndex: number,
+  currentPosition: string[][],
+  piece: string
+) => {
+  const moves: [number, number][] = [];
+  const currentPlayer = piece[0];
+  const opponent = currentPlayer === 'w' ? 'b' : 'w';
+
+  const bishopsDirections = [
+    [1, 1],
+    [1, -1],
+    [-1, 1],
+    [-1, -1]
+  ];
+
+  bishopsDirections.forEach((direction) => {
+    for (let i = 1; i < 8; i++) {
+      const x = rank + i * direction[0];
+      const y = fileIndex + i * direction[1];
+
+      const isOutOfBoard = currentPosition?.[x]?.[y] === undefined;
+      if (isOutOfBoard) {
+        break;
+      }
+
+      if (currentPosition[x][y].startsWith(opponent)) {
+        moves.push([x, y]);
+        break;
+      }
+
+      const isOccupiedByAlly = currentPosition[x][y].startsWith(currentPlayer);
+
+      if (isOccupiedByAlly) {
+        break;
+      }
+
+      moves.push([x, y]);
+    }
+  });
+
+  return moves;
+};


### PR DESCRIPTION
# Summary

- Add the `getBishopMoves` function in `app/utils/arbiter/getMoves.ts`. This function calculates all valid moves for a bishop based on its position, ensuring moves stay within bounds and account for ally and opponent pieces.
- Modify the `arbiter` object in `app/utils/arbiter/arbiter.ts` to handle pieces ending in 'b' by invoking the new `getBishopMoves` function.
  
# Details
 
- Add bishops' funcionality.

