### PR TITLE
feat: queens

### DIFF
--- a/app/utils/arbiter/arbiter.ts
+++ b/app/utils/arbiter/arbiter.ts
@@ -1,4 +1,9 @@
-import { getBishopMoves, getKnightMoves, getRookMoves } from './getMoves';
+import {
+  getBishopMoves,
+  getKnightMoves,
+  getQueenMoves,
+  getRookMoves
+} from './getMoves';
 
 const arbiter = {
   getRegularMoves: function (
@@ -17,6 +22,10 @@ const arbiter = {
 
     if (piece.endsWith('b')) {
       return getBishopMoves(rank, fileIndex, position, piece);
+    }
+
+    if (piece.endsWith('q')) {
+      return getQueenMoves(rank, fileIndex, position, piece);
     }
 
     return [];

--- a/app/utils/arbiter/getMoves.ts
+++ b/app/utils/arbiter/getMoves.ts
@@ -125,3 +125,13 @@ export const getBishopMoves = (
 
   return moves;
 };
+
+export const getQueenMoves = (
+  rank: number,
+  fileIndex: number,
+  currentPosition: string[][],
+  piece: string
+) => [
+  ...getRookMoves(rank, fileIndex, currentPosition, piece),
+  ...getBishopMoves(rank, fileIndex, currentPosition, piece)
+];


### PR DESCRIPTION
# Summary

- Add a new `getQueenMoves` function that combines rook and bishop moves to calculate the queen's possible moves.
-  Update imports to include `getQueenMoves` and added logic to handle queen pieces (`piece.endsWith('q')`) in the `getRegularMoves` function.

# Details

- Add queen functionalities.

# Evidences

## Candidate Moves for White Queen
![image](https://github.com/user-attachments/assets/81c61387-5397-4c84-b597-cab59b5df4fb)
