### PR TITLE
feat: pawns

### DIFF
--- a/app/board/components/Piece.tsx
+++ b/app/board/components/Piece.tsx
@@ -13,7 +13,9 @@ type PieceProps = {
 const Piece: FC<PieceProps> = ({ piece, fileIndex, rank }) => {
   const { state, dispatch } = useAppContext();
   const { turn, position } = state;
+
   const currentPosition = position[position.length - 1];
+  const previousPosition = position[position.length - 2];
 
   const onDragStart = (e: DragEvent) => {
     e.dataTransfer.effectAllowed = 'move';
@@ -27,7 +29,8 @@ const Piece: FC<PieceProps> = ({ piece, fileIndex, rank }) => {
         rank,
         fileIndex,
         currentPosition,
-        piece
+        piece,
+        previousPosition
       );
 
       dispatch(generateCandidateMoves(candidateMoves));

--- a/app/board/components/Pieces.tsx
+++ b/app/board/components/Pieces.tsx
@@ -45,6 +45,16 @@ const Pieces: FC = () => {
     );
 
     if (isValidMove) {
+      const wasEnPassantCapture =
+        piece.endsWith('p') &&
+        Math.abs(fileIndex - originalFile) === 1 &&
+        Math.abs(rankIndex - originalRank) === 1 &&
+        !newPosition[rankIndex][fileIndex];
+
+      if (wasEnPassantCapture) {
+        newPosition[originalRank][fileIndex] = '';
+      }
+
       newPosition[originalRank][originalFile] = '';
       newPosition[rankIndex][fileIndex] = piece;
 

--- a/app/reducer/reducer.ts
+++ b/app/reducer/reducer.ts
@@ -13,12 +13,13 @@ function reducer(state: State, action: Action): State {
       let { turn, position } = state;
       turn = turn === turns.WHITE ? turns.BLACK : turns.WHITE;
 
-      position = (action.payload as MoveAction).position;
+      position = [...position, ...(action.payload as MoveAction).position];
 
       return {
         ...state,
         position,
-        turn
+        turn,
+        candidateMoves: []
       };
     }
 

--- a/app/utils/arbiter/arbiter.ts
+++ b/app/utils/arbiter/arbiter.ts
@@ -2,6 +2,8 @@ import {
   getBishopMoves,
   getKingMoves,
   getKnightMoves,
+  getPawnCaptures,
+  getPawnMoves,
   getQueenMoves,
   getRookMoves
 } from './getMoves';
@@ -11,7 +13,8 @@ const arbiter = {
     rank: number,
     fileIndex: number,
     position: string[][],
-    piece: string
+    piece: string,
+    previousPosition: string[][]
   ) {
     if (piece.endsWith('r')) {
       return getRookMoves(rank, fileIndex, position, piece);
@@ -31,6 +34,10 @@ const arbiter = {
 
     if (piece.endsWith('k')) {
       return getKingMoves(rank, fileIndex, position, piece);
+    }
+
+    if (piece.endsWith('p')) {
+      return [...getPawnMoves(rank, fileIndex, position, piece), ...getPawnCaptures(rank, fileIndex, position, piece, previousPosition)];
     }
 
     return [];

--- a/app/utils/arbiter/getMoves.ts
+++ b/app/utils/arbiter/getMoves.ts
@@ -173,3 +173,86 @@ export const getQueenMoves = (
   ...getRookMoves(rank, fileIndex, currentPosition, piece),
   ...getBishopMoves(rank, fileIndex, currentPosition, piece)
 ];
+
+export const getPawnMoves = (
+  rank: number,
+  fileIndex: number,
+  currentPosition: string[][],
+  piece: string
+) => {
+  const moves: [number, number][] = [];
+  const direction = piece === 'wp' ? 1 : -1;
+
+  const oneStepForward = rank + direction;
+
+  if (oneStepForward >= 0 && oneStepForward <= 7) {
+    if (currentPosition[oneStepForward][fileIndex] === '') {
+      moves.push([oneStepForward, fileIndex]);
+
+      const isStartingPosition =
+        (piece === 'wp' && rank === 1) || (piece === 'bp' && rank === 6);
+      const twoStepsForward = rank + direction * 2;
+
+      if (isStartingPosition && twoStepsForward >= 0 && twoStepsForward <= 7) {
+        if (currentPosition[twoStepsForward][fileIndex] === '') {
+          moves.push([twoStepsForward, fileIndex]);
+        }
+      }
+    }
+  }
+
+  return moves;
+};
+
+export const getPawnCaptures = (
+  rank: number,
+  fileIndex: number,
+  currentPosition: string[][],
+  piece: string,
+  previousPosition: string[][]
+) => {
+  const moves: [number, number][] = [];
+  const direction = piece === 'wp' ? 1 : -1;
+  const enemy = piece.startsWith('w') ? 'b' : 'w';
+
+  const diagonalFiles = [fileIndex - 1, fileIndex + 1];
+  diagonalFiles.forEach((file) => {
+    if (file >= 0 && file <= 7) {
+      const targetRank = rank + direction;
+      if (targetRank >= 0 && targetRank <= 7) {
+        const targetPiece = currentPosition[targetRank]?.[file];
+        if (targetPiece?.startsWith(enemy)) {
+          moves.push([targetRank, file]);
+        }
+      }
+    }
+  });
+
+  if (previousPosition) {
+    const enPassantRank = piece === 'wp' ? 4 : 3;
+
+    if (rank === enPassantRank) {
+      diagonalFiles.forEach((file) => {
+        if (file >= 0 && file <= 7) {
+          const enemyPawn = enemy + 'p';
+          const currentEnemyPiece = currentPosition[rank]?.[file];
+          const previousEnemyPosition = previousPosition[rank]?.[file];
+
+          const enemyStartRank = enemy === 'w' ? 1 : 6;
+          const previousEnemyStartPosition =
+            previousPosition[enemyStartRank]?.[file];
+
+          const condition1 = currentEnemyPiece === enemyPawn;
+          const condition2 = previousEnemyPosition === '';
+          const condition3 = previousEnemyStartPosition === enemyPawn;
+
+          if (condition1 && condition2 && condition3) {
+            moves.push([rank + direction, file]);
+          }
+        }
+      });
+    }
+  }
+
+  return moves;
+};


### PR DESCRIPTION
# Summary

- Add `getPawnMoves` and `getPawnCaptures` functions to handle standard pawn moves, diagonal captures, and en passant captures. These functions include logic for detecting en passant conditions based on the current and previous board positions.
- Update the `arbiter` utility to support pawn-specific move generation by integrating the new `getPawnMoves` and `getPawnCaptures` functions. The `previousPosition` parameter was added to enable en passant detection.
- Add logic to handle en passant captures, ensuring the captured pawn is removed from the board when the en passant condition is met.
- Modify the reducer to append new positions to the `position` array instead of replacing it, enabling tracking of previous positions for en passant logic. Additionally, reset `candidateMoves` after each move.
- Introduce `previousPosition` to the `Piece` component to facilitate en passant capture logic during drag-and-drop interactions. 

# Details

- Add pawns feature.
- Fix position history.

# Evidences

## Initial Candidate Movements
![image](https://github.com/user-attachments/assets/a8d2d11a-a67a-4bc0-a357-45958e242c22)

## Candidate Capture
![image](https://github.com/user-attachments/assets/cbf4ba10-2961-4659-9611-ab9558381938)

## En Passant Candidate Capture
![image](https://github.com/user-attachments/assets/5ccc4128-301f-4412-a710-edc116635bd0)
